### PR TITLE
Fix compilation with >=GCC-12 and Musl

### DIFF
--- a/glcdskin/type.h
+++ b/glcdskin/type.h
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <time.h>
+
 namespace GLCD
 {
 


### PR DESCRIPTION
This will fix a compiling failure:
g++  -O2 -pipe -MMD -MP -MMD -MP -fPIC -I.. -c -D_GNU_SOURCE  skin.c In file included from config.c:2:
type.h:48:17: error: expected ')' before 'Number'
   48 |     cType(time_t Number): mType(number), mNumber(Number), mUpdateIn(0) {}
      |          ~      ^~~~~~~
      |                 )

Signed-off-by: Conrad Kostecki <conikost@gentoo.org>